### PR TITLE
Add pypy publish on GitHub Release & Pypy badge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+on:
+  release:
+    types: [published]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version:  ${{ matrix.python-version }}
+
+    - name: Install Poetry
+        uses: dschep/install-poetry-action@v1.2
+
+    - run: poetry build
+    - run: poetry publish --username=__token__ --password=${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dublin Region Energy Masterplan (drem)
 
 [![Codecov](https://codecov.io/gh/codema-dev/drem/branch/master/graph/badge.svg)](https://codecov.io/gh/codema-dev/drem)
+[![PyPI](https://img.shields.io/pypi/v/drem.svg)](https://pypi.org/project/drem/)
 
 ## Installation
 


### PR DESCRIPTION
So can publish to PyPy directly from Github via Release

See: [Uploading your package to PyPI](https://medium.com/@cjolowicz/hypermodern-python-6-ci-cd-b233accfa2f6#efd9)