### PR TITLE
Manually patch pyproject from 0.1.0 to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "drem"
-version = "0.1.0"
+version = "0.1.1"
 description = "https://www.codema.ie/projects/local-projects/dublin-region-energy-master-plan"
 authors = ["Rowan Molony <rowan.molony@codema.ie>"]
 license = "MIT"


### PR DESCRIPTION
Github Release action failed due to an extra whitespace bug so manually bump up version number and publish to PyPi