### PR TITLE
Remove merge conflict from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,6 @@
 [tool.poetry]
 name = "drem"
-<<<<<<< Updated upstream
-version = "0.1.1"
-=======
 version = "0.1.2"
->>>>>>> Stashed changes
 description = "https://www.codema.ie/projects/local-projects/dublin-region-energy-master-plan"
 authors = ["Rowan Molony <rowan.molony@codema.ie>"]
 license = "MIT"


### PR DESCRIPTION
When Github Actions ran `release.yml` it bumped up the project version which resulted in a merge conflict...