### PR TITLE
Add Merge Conflict Check to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Check for Merge Conflicts
+      uses: olivernybroe/action-conflict-finder@v1.1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Check for Merge Conflicts
+      uses: olivernybroe/action-conflict-finder@v1.1
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
So that CI doesn't break again due to a merge
conflict error...  Poetry broke in #44 due to
a pyproject.toml version conflict