### PR TITLE
Create function to add parquet metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,11 +9,15 @@ ignore =
     Q000,
     E501, E1120, E1102,
 
+    WPS305, WPS110, WPS348, WPS436, WPS412, WPS111, WPS347, WPS441, WPS226, WPS450,
+
+    # '.read_csv' is preferred to '.read_table'; provides same functionality
+    # -> mistakenly thinks pq (pyarrow.parquet) is pd (pandas)
+    PDO12
+
     # S101 Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
     # -> pytest assert
     S101,
-
-    WPS305, WPS110, WPS348, WPS436, WPS412, WPS111, WPS347, WPS441, WPS226, WPS450,
 
     # Found useless lambda declaration -> icontract lambdas
     WPS506,
@@ -32,6 +36,13 @@ ignore =
 
     # Found module with too many imports -> importing private functions in pytest
     WPS201 Found module with too many import
+
+    # WPS301 Found dotted raw import -> importing pyarrow.parquet as pq
+    WPS301
+
+    # Found too long name -> pytest test names...
+    WPS118
+
 
 import-order-style=google
 

--- a/src/drem/filepaths.py
+++ b/src/drem/filepaths.py
@@ -14,4 +14,4 @@ REQUESTS_DIR = DATA_DIR / "requests"
 
 UTEST_DATA_EXTERNAL = TEST_DIR / "unit" / "extract" / "data"
 UTEST_DATA_TRANSFORM = TEST_DIR / "unit" / "transform" / "data"
-FTEST_DATA_TRANSFORM = TEST_DIR / "functional" / "transform" / "data"
+FTEST_DATA = TEST_DIR / "functional" / "data"

--- a/src/drem/utilities/parquet_metadata.py
+++ b/src/drem/utilities/parquet_metadata.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pyarrow.parquet as pq
+
+
+def add_file_engine_metadata_to_parquet_file(filepath: Path, file_engine: str) -> None:
+    """Add file engine metadata ('pandas' or 'geopandas') to existing parquet file.
+
+    Args:
+        filepath (Path): Path to parquet file
+        file_engine (str): Engine to be used to read the file
+        (options: 'pandas', 'geopandas')
+    """
+    table = pq.read_table(filepath)
+
+    custom_metadata = {"file_engine": file_engine}
+    existing_metadata = table.schema.metadata
+    merged_metadata = {**custom_metadata, **existing_metadata}
+    fixed_table = table.replace_schema_metadata(merged_metadata)
+
+    pq.write_table(fixed_table, filepath)

--- a/tests/unit/utilities/test_parquet_metadata.py
+++ b/tests/unit/utilities/test_parquet_metadata.py
@@ -1,0 +1,31 @@
+import geopandas as gpd
+import pandas as pd
+import pyarrow.parquet as pq
+
+from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
+
+
+def test_add_pandas_engine_metadata_to_parquet_file(tmp_path) -> None:
+    """Pandas engine metadata added.
+
+    Args:
+        tmp_path ([type]): Pytest temporary path plugin
+    """
+    filepath = tmp_path / "test_meta.parquet"
+    pd.DataFrame().to_parquet(filepath)
+    add_file_engine_metadata_to_parquet_file(filepath, "pandas")
+
+    assert pq.read_metadata(filepath).metadata[b"file_engine"] == b"pandas"
+
+
+def test_add_geopandas_engine_metadata_to_parquet_file(tmp_path) -> None:
+    """Geopandas engine metadata added.
+
+    Args:
+        tmp_path ([type]): Pytest temporary path plugin
+    """
+    filepath = tmp_path / "test_meta.parquet"
+    gpd.GeoDataFrame().to_parquet(filepath)
+    add_file_engine_metadata_to_parquet_file(filepath, "geopandas")
+
+    assert pq.read_metadata(filepath).metadata[b"file_engine"] == b"geopandas"


### PR DESCRIPTION
So can automate the generation of sample test data
as can read parquet metadata to check if pandas or geopandas
should be used as engine