### PR TITLE
Add file engine metadata to files on extract

### DIFF
--- a/src/drem/extract/ber.py
+++ b/src/drem/extract/ber.py
@@ -13,6 +13,7 @@ from drem.extract.download import download_file_from_response
 from drem.extract.read_json import read_json
 from drem.extract.zip import unzip_file
 from drem.filepaths import REQUESTS_DIR
+from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
 
 
 CWD: Path = Path.cwd()
@@ -85,5 +86,7 @@ def extract_ber(email_address: str, savedir: Optional[Path] = CWD) -> pd.DataFra
         ).to_parquet(filepath_parquet)
 
         rmtree(filepath_unzipped)
+
+        add_file_engine_metadata_to_parquet_file(filepath_parquet, "pandas")
 
     return pd.read_parquet(filepath_parquet)

--- a/src/drem/extract/dublin_postcodes.py
+++ b/src/drem/extract/dublin_postcodes.py
@@ -9,6 +9,7 @@ from prefect import task
 
 from drem.extract.download import download
 from drem.extract.zip import unzip_file
+from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
 
 
 CWD = Path.cwd()
@@ -52,5 +53,7 @@ def extract_dublin_postcodes(savedir: Path = CWD) -> gpd.GeoDataFrame:
         ).to_parquet(filepath_parquet)
 
         rmtree(filepath_unzipped)
+
+        add_file_engine_metadata_to_parquet_file(filepath_parquet, "geopandas")
 
     return gpd.read_parquet(filepath_parquet)

--- a/src/drem/extract/sa_geometries.py
+++ b/src/drem/extract/sa_geometries.py
@@ -9,6 +9,7 @@ from prefect import task
 
 from drem.extract.download import download
 from drem.extract.zip import unzip_file
+from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
 
 
 CWD = Path.cwd()
@@ -48,5 +49,7 @@ def extract_sa_geometries(savedir: Path = CWD) -> gpd.GeoDataFrame:
         gpd.read_file(filepath_unzipped).to_parquet(filepath_parquet)
 
         rmtree(filepath_unzipped)
+
+        add_file_engine_metadata_to_parquet_file(filepath_parquet, "geopandas")
 
     return gpd.read_parquet(filepath_parquet)

--- a/src/drem/extract/sa_statistics.py
+++ b/src/drem/extract/sa_statistics.py
@@ -7,6 +7,7 @@ import pandas as pd
 from prefect import task
 
 from drem.extract.download import download
+from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
 
 
 CWD = Path.cwd()
@@ -42,6 +43,8 @@ def extract_sa_statistics(savedir: Path = CWD) -> pd.DataFrame:
 
         pd.read_csv(filepath_csv).to_parquet(filepath_parquet)
 
+        add_file_engine_metadata_to_parquet_file(filepath_parquet, "pandas")
+
     return pd.read_parquet(filepath_parquet)
 
 
@@ -74,5 +77,7 @@ def extract_sa_glossary(savedir: Path = CWD) -> pd.DataFrame:
         )
 
         pd.read_excel(filepath_excel, engine="openpyxl").to_parquet(filepath_parquet)
+
+        add_file_engine_metadata_to_parquet_file(filepath_parquet, "pandas")
 
     return pd.read_parquet(filepath_parquet)


### PR DESCRIPTION
Actually implement metadata engine function during extract so can generate test data via a function by reading the metadata prior to using `pandas` or `geopandas` to read parquet