### PR TITLE
Block http requests in pytest conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from _pytest.monkeypatch import MonkeyPatch
 from tdda.referencetest import referencepytest
 
 
@@ -16,3 +17,23 @@ def pytest_collection_modifyitems(session, config, items):
 @pytest.fixture(scope="module")
 def ref(request):
     return referencepytest.ref(request)
+
+
+@pytest.fixture(autouse=True)
+def no_http_requests(monkeypatch):
+    """Prevent any test from making HTTP requests.
+
+    Source: https://blog.jerrycodes.com/no-http-requests/
+
+    Args:
+        monkeypatch (MonkeyPatch): [description]
+    """
+
+    def urlopen_mock(self, method, url, *args, **kwargs):
+        raise RuntimeError(
+            f"The test was about to {method} {self.scheme}://{self.host}{url}",
+        )
+
+    monkeypatch.setattr(
+        "urllib3.connectionpool.HTTPConnectionPool.urlopen", urlopen_mock,
+    )

--- a/tests/unit/utilities/test_http_request_is_blocked.py
+++ b/tests/unit/utilities/test_http_request_is_blocked.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+import pytest
+
+from drem.extract.download import download
+
+
+def test_task_http_request_is_blocked(tmp_path: Path) -> None:
+    """No_http_requests fixture in conftest blocks http requests.
+
+    Args:
+        tmp_path (Path): A Pytest plugin to create a temporary path
+    """
+    with pytest.raises(RuntimeError):
+        download("http://www.url-to-some-file.com", tmp_path)


### PR DESCRIPTION
So that ftest pipeline does not accidentally try to
download files via http requests