### PR TITLE
Remove metadata marking during extract tasks

### DIFF
--- a/src/drem/extract/ber.py
+++ b/src/drem/extract/ber.py
@@ -13,7 +13,6 @@ from drem.extract.download import download_file_from_response
 from drem.extract.read_json import read_json
 from drem.extract.zip import unzip_file
 from drem.filepaths import REQUESTS_DIR
-from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
 
 
 CWD: Path = Path.cwd()
@@ -86,7 +85,5 @@ def extract_ber(email_address: str, savedir: Optional[Path] = CWD) -> pd.DataFra
         ).to_parquet(filepath_parquet)
 
         rmtree(filepath_unzipped)
-
-        add_file_engine_metadata_to_parquet_file(filepath_parquet, "pandas")
 
     return pd.read_parquet(filepath_parquet)

--- a/src/drem/extract/dublin_postcodes.py
+++ b/src/drem/extract/dublin_postcodes.py
@@ -9,7 +9,6 @@ from prefect import task
 
 from drem.extract.download import download
 from drem.extract.zip import unzip_file
-from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
 
 
 CWD = Path.cwd()
@@ -53,7 +52,5 @@ def extract_dublin_postcodes(savedir: Path = CWD) -> gpd.GeoDataFrame:
         ).to_parquet(filepath_parquet)
 
         rmtree(filepath_unzipped)
-
-        add_file_engine_metadata_to_parquet_file(filepath_parquet, "geopandas")
 
     return gpd.read_parquet(filepath_parquet)

--- a/src/drem/extract/sa_geometries.py
+++ b/src/drem/extract/sa_geometries.py
@@ -9,7 +9,6 @@ from prefect import task
 
 from drem.extract.download import download
 from drem.extract.zip import unzip_file
-from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
 
 
 CWD = Path.cwd()
@@ -49,7 +48,5 @@ def extract_sa_geometries(savedir: Path = CWD) -> gpd.GeoDataFrame:
         gpd.read_file(filepath_unzipped).to_parquet(filepath_parquet)
 
         rmtree(filepath_unzipped)
-
-        add_file_engine_metadata_to_parquet_file(filepath_parquet, "geopandas")
 
     return gpd.read_parquet(filepath_parquet)

--- a/src/drem/extract/sa_statistics.py
+++ b/src/drem/extract/sa_statistics.py
@@ -7,7 +7,6 @@ import pandas as pd
 from prefect import task
 
 from drem.extract.download import download
-from drem.utilities.parquet_metadata import add_file_engine_metadata_to_parquet_file
 
 
 CWD = Path.cwd()
@@ -43,8 +42,6 @@ def extract_sa_statistics(savedir: Path = CWD) -> pd.DataFrame:
 
         pd.read_csv(filepath_csv).to_parquet(filepath_parquet)
 
-        add_file_engine_metadata_to_parquet_file(filepath_parquet, "pandas")
-
     return pd.read_parquet(filepath_parquet)
 
 
@@ -77,7 +74,5 @@ def extract_sa_glossary(savedir: Path = CWD) -> pd.DataFrame:
         )
 
         pd.read_excel(filepath_excel, engine="openpyxl").to_parquet(filepath_parquet)
-
-        add_file_engine_metadata_to_parquet_file(filepath_parquet, "pandas")
 
     return pd.read_parquet(filepath_parquet)


### PR DESCRIPTION
Am no longer using metadata logic to sample files for
ftest pipeline so this isn't needed (also adds overhead...)