### PR TITLE
Ignore UserWarning, FutureWarning, PendingDeprecationWarning in Pytest

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -3,3 +3,7 @@ addopts = --strict-markers
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     e2e: marks end-to-end tests which take longer to run as exercise multiple functions
+filterwarnings =
+    ignore::UserWarning
+    ignore::FutureWarning
+    ignore::PendingDeprecationWarning


### PR DESCRIPTION
UserWarning says that geopandas parquet is unstable...

FutureWarning says ast (dependency of a dependency) will
soon become deprecated...

PendingDeprecationWarning says tdda depends on deprecated
pd.np...