### PR TITLE
Fix Agg Small Area Demands

### DIFF
--- a/src/drem/transform/sa_statistics.py
+++ b/src/drem/transform/sa_statistics.py
@@ -1,6 +1,7 @@
 from typing import List
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
 
 from icontract import ensure
@@ -144,7 +145,16 @@ def _estimate_total_residential_heat_demand_per_small_area(
         * small_area_statistics["mean_heat_demand_per_hh"]
     )
 
-    return small_area_statistics[["small_area", "total_heat_demand_per_sa", "geometry"]]
+    small_area_statistics_aggregated = (
+        small_area_statistics[["small_area", "total_heat_demand_per_sa", "geometry"]]
+        .pivot_table(
+            index="small_area", values=["total_heat_demand_per_sa"], aggfunc=np.mean,
+        )
+        .reset_index()
+        .merge(small_area_statistics[["small_area", "geometry"]])
+    )
+
+    return gpd.GeoDataFrame(small_area_statistics_aggregated, crs="epsg:4326")
 
 
 @task(name="Transform CSO Small Area Statistics via Glossary")

--- a/tests/unit/transform/test_sa_statistics.py
+++ b/tests/unit/transform/test_sa_statistics.py
@@ -234,10 +234,11 @@ def test_estimate_total_residential_heat_demand_per_small_area() -> None:
             "total_heat_demand_per_sa": [345126.894],
             "geometry": [Point((1, 1))],
         },
+        crs="epsg:4326",
     )
 
     output: gpd.GeoDataFrame = _estimate_total_residential_heat_demand_per_small_area(
         small_area_statistics,
     )
 
-    assert_geodataframe_equal(output, expected_output)
+    assert_geodataframe_equal(output, expected_output, check_like=True)


### PR DESCRIPTION
Forgot to groupby Small Area and aggregate total_heat_demand_by_sa
so geopandas plotting would have bugged out as would have had
duplicate geometries for each small_area...

Now total_heat_demand_by_sa actually represents total_heat_demand_by_sa!