### PR TITLE
Drop duplicate total_heat_demand and sum archetypes

### DIFF
--- a/src/drem/transform/sa_statistics.py
+++ b/src/drem/transform/sa_statistics.py
@@ -140,18 +140,24 @@ def _estimate_total_residential_heat_demand_per_small_area(
     small_area_statistics: gpd.GeoDataFrame,
 ) -> gpd.GeoDataFrame:
 
-    small_area_statistics["total_heat_demand_per_sa"] = (
+    small_area_statistics["total_heat_demand_per_archetype"] = (
         small_area_statistics["households"]
         * small_area_statistics["mean_heat_demand_per_hh"]
     )
 
     small_area_statistics_aggregated = (
-        small_area_statistics[["small_area", "total_heat_demand_per_sa", "geometry"]]
+        small_area_statistics[
+            ["small_area", "total_heat_demand_per_archetype", "geometry"]
+        ]
         .pivot_table(
-            index="small_area", values=["total_heat_demand_per_sa"], aggfunc=np.mean,
+            index="small_area",
+            values=["total_heat_demand_per_archetype"],
+            aggfunc=np.sum,
         )
         .reset_index()
         .merge(small_area_statistics[["small_area", "geometry"]])
+        .drop_duplicates()
+        .rename(columns={"total_heat_demand_per_archetype": "total_heat_demand_per_sa"})
     )
 
     return gpd.GeoDataFrame(small_area_statistics_aggregated, crs="epsg:4326")

--- a/tests/unit/transform/test_sa_statistics.py
+++ b/tests/unit/transform/test_sa_statistics.py
@@ -219,19 +219,19 @@ def test_estimate_total_residential_heat_demand_per_small_area() -> None:
     """Total residential heat demand output matches expected output."""
     small_area_statistics: gpd.GeoDataFrame = gpd.GeoDataFrame(
         {
-            "small_area": [267112002],
-            "period_built": ["1971 - 1980"],
-            "households": [21],
-            "postcodes": ["Dublin 24"],
-            "geometry": [Point((1, 1))],
-            "mean_heat_demand_per_hh": [16434.614],
+            "small_area": [267112002, 267112002],
+            "period_built": ["1971 - 1980", "before 1919"],
+            "households": [21, 10],
+            "postcodes": ["Dublin 24", "Dublin 24"],
+            "geometry": [Point((1, 1)), Point((1, 1))],
+            "mean_heat_demand_per_hh": [15000, 20000],
         },
     )
 
     expected_output: gpd.GeoDataFrame = gpd.GeoDataFrame(
         {
             "small_area": [267112002],
-            "total_heat_demand_per_sa": [345126.894],
+            "total_heat_demand_per_sa": [515000],
             "geometry": [Point((1, 1))],
         },
         crs="epsg:4326",


### PR DESCRIPTION
As a result of hackily linking geometry values back to
a groupby sum operation duplicate rows are created...
Drop em

Mistakenly calculated the mean of the archetypes instead
of summing them, now fixed...