### PR TITLE
Copy vo-cibse links to a yaml file by category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ dask-worker-space
 !/data/requests
 !/data/roughwork
 /data/roughwork/*
+/data/links/*
 
 # exclude external libraries by default
 /externals/*

--- a/src/drem/filepaths.py
+++ b/src/drem/filepaths.py
@@ -12,6 +12,7 @@ INTERIM_DIR = DATA_DIR / "interim"
 EXTERNAL_DIR = DATA_DIR / "external"
 REQUESTS_DIR = DATA_DIR / "requests"
 ROUGHWORK_DIR = DATA_DIR / "roughwork"
+LINKS_DIR = DATA_DIR / "links"
 
 FTEST_DATA = TEST_DIR / "functional" / "data"
 FTEST_DATA_EXTERNAL = TEST_DIR / "functional" / "data" / "external"

--- a/src/drem/utilities/link_vo_to_cibse.py
+++ b/src/drem/utilities/link_vo_to_cibse.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import Dict
+
+import pandas as pd
+import yaml
+
+
+def _convert_dataframe_to_dict_of_lists(vo_cibse_link: pd.DataFrame) -> Dict[str, str]:
+    """Convert pandas DataFrame into a Dictionary of Lists.
+
+    Args:
+        vo_cibse_link (pd.DataFrame): Data to be converted
+
+    Returns:
+        Dict[str, str]: Converted output
+
+    Example output:
+        {"General Retail (TM:46)": ["KIOSK CLOTHES SHOP", ...]}
+    """
+    return {
+        idx: group["Uses"].drop_duplicates().tolist()
+        for idx, group in vo_cibse_link.groupby("CATEGORY")
+    }
+
+
+def _save_dict_to_yamls(vo_by_category: Dict[str, str], savedir: Path) -> None:
+
+    for key in vo_by_category.keys():
+
+        with open(savedir / "".join([key, ".yaml"]), "w") as file:
+            yaml.dump({key: vo_by_category[key]}, file)
+
+
+def copy_vo_cibse_link_from_excel_to_yamls(filepath: Path, savedir: Path) -> None:
+    """Copy Valuation-Office-to-CIBSE-Benchmark links from Excel to yamls.
+
+    Where each yaml represents a different CIBSE category... Can add new categories to
+    these yamls in the future as they are added to the Valuation Office data...
+
+    Args:
+        filepath (Path): Filepath to Excel file containing labels
+        savedir (Path): Path to directory where data will be saved
+    """
+    vo_cibse_link: pd.DataFrame = pd.read_excel(filepath, engine="openpyxl")
+
+    vo_cibse_link.loc[:, "CATEGORY"] = vo_cibse_link["CATEGORY"].str.replace(
+        "/", " or ", regex=True,
+    )
+
+    vo_by_category: Dict[str, str] = _convert_dataframe_to_dict_of_lists(vo_cibse_link)
+    _save_dict_to_yamls(vo_by_category, savedir)

--- a/tests/unit/utilities/test_link_vo_to_cibse.py
+++ b/tests/unit/utilities/test_link_vo_to_cibse.py
@@ -1,0 +1,53 @@
+from os import listdir
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from drem.utilities.link_vo_to_cibse import copy_vo_cibse_link_from_excel_to_yamls
+
+
+@pytest.fixture
+def path_to_vo_cibse_link(tmp_path: Path) -> Path:
+    """Create dummy data of vo to cibse link.
+
+    Args:
+        tmp_path (Path): A Pytest plugin to create a temporary path
+
+    Returns:
+        Path: Path to dummy data file location
+    """
+    vo_cibse_link: pd.DataFrame = pd.DataFrame(
+        {
+            "Uses": [
+                "KIOSK CLOTHES SHOP",
+                "COFFEE SHOP STORE",
+                "MISCELLANEOUS SURGERY",
+            ],
+            "CATEGORY": [
+                "General Retail (TM:46)",
+                "Retail: Small Food Shop",
+                "Clinic: Health center/Clinic/Surgery (TM46)",
+            ],
+        },
+    )
+
+    path_to_vo_cibse_link: Path = tmp_path / "link-vo-to-cibse.xlsx"
+
+    vo_cibse_link.to_excel(path_to_vo_cibse_link, engine="openpyxl")
+
+    return path_to_vo_cibse_link
+
+
+def test_copy_vo_cibse_link_from_excel_to_yamls(
+    path_to_vo_cibse_link: Path, tmp_path: Path,
+) -> None:
+    """Copy VO-to-CIBSE links to a yaml named after each category containing uses.
+
+    Args:
+        path_to_vo_cibse_link (Path): Path to vo-cibse-link dummy data
+        tmp_path (Path): A Pytest plugin to create a temporary path
+    """
+    copy_vo_cibse_link_from_excel_to_yamls(path_to_vo_cibse_link, tmp_path)
+
+    assert "General Retail (TM:46).yaml" in listdir(tmp_path)


### PR DESCRIPTION
Yamls by category are easier to add to in future when
additional Uses are added to the Valuation Office dataset
and need to be linked back to a category...