### PR TITLE
Refactor vo-cibse link storage from yaml to txt

### DIFF
--- a/src/drem/utilities/link_vo_to_cibse.py
+++ b/src/drem/utilities/link_vo_to_cibse.py
@@ -1,15 +1,21 @@
 from pathlib import Path
 from typing import Dict
+from typing import List
 
 import pandas as pd
-import yaml
+
+import drem
 
 
-def _convert_dataframe_to_dict_of_lists(vo_cibse_link: pd.DataFrame) -> Dict[str, str]:
+def _convert_dataframe_to_dict_of_lists(
+    vo_cibse_link: pd.DataFrame, category_col: str, uses_col: str,
+) -> Dict[str, str]:
     """Convert pandas DataFrame into a Dictionary of Lists.
 
     Args:
         vo_cibse_link (pd.DataFrame): Data to be converted
+        category_col (str): Column name of CIBSE 'category' column
+        uses_col (str): Column name of Valuation Office 'uses' column
 
     Returns:
         Dict[str, str]: Converted output
@@ -18,20 +24,26 @@ def _convert_dataframe_to_dict_of_lists(vo_cibse_link: pd.DataFrame) -> Dict[str
         {"General Retail (TM:46)": ["KIOSK CLOTHES SHOP", ...]}
     """
     return {
-        idx: group["Uses"].drop_duplicates().tolist()
-        for idx, group in vo_cibse_link.groupby("CATEGORY")
+        idx: group[uses_col].drop_duplicates().tolist()
+        for idx, group in vo_cibse_link.groupby(category_col)
     }
 
 
-def _save_dict_to_yamls(vo_by_category: Dict[str, str], savedir: Path) -> None:
+def _save_dict_to_text_file(vo_by_category: Dict[str, str], savedir: Path) -> None:
 
     for key in vo_by_category.keys():
 
-        with open(savedir / "".join([key, ".yaml"]), "w") as file:
-            yaml.dump({key: vo_by_category[key]}, file)
+        filepath: Path = savedir / "".join([key, ".txt"])
+
+        data: List[str] = ["".join([str(item), "\n"]) for item in vo_by_category[key]]
+
+        with open(filepath, "a") as text_file:
+            text_file.writelines(data)
 
 
-def copy_vo_cibse_link_from_excel_to_yamls(filepath: Path, savedir: Path) -> None:
+def copy_vo_cibse_link_from_excel_to_text_files(
+    filepath: Path, savedir: Path, category_col: str, uses_col: str,
+) -> None:
     """Copy Valuation-Office-to-CIBSE-Benchmark links from Excel to yamls.
 
     Where each yaml represents a different CIBSE category... Can add new categories to
@@ -40,12 +52,32 @@ def copy_vo_cibse_link_from_excel_to_yamls(filepath: Path, savedir: Path) -> Non
     Args:
         filepath (Path): Filepath to Excel file containing labels
         savedir (Path): Path to directory where data will be saved
+        category_col (str): Column name of CIBSE 'category' column
+        uses_col (str): Column name of Valuation Office 'uses' column
     """
     vo_cibse_link: pd.DataFrame = pd.read_excel(filepath, engine="openpyxl")
 
-    vo_cibse_link.loc[:, "CATEGORY"] = vo_cibse_link["CATEGORY"].str.replace(
+    vo_cibse_link.loc[:, category_col] = vo_cibse_link[category_col].str.replace(
         "/", " or ", regex=True,
     )
 
-    vo_by_category: Dict[str, str] = _convert_dataframe_to_dict_of_lists(vo_cibse_link)
-    _save_dict_to_yamls(vo_by_category, savedir)
+    vo_by_category: Dict[str, str] = _convert_dataframe_to_dict_of_lists(
+        vo_cibse_link, category_col, uses_col,
+    )
+    _save_dict_to_text_file(vo_by_category, savedir)
+
+
+if __name__ == "__main__":
+
+    copy_vo_cibse_link_from_excel_to_text_files(
+        drem.filepaths.RAW_DIR / "cibse-vo.xlsx",
+        drem.filepaths.LINKS_DIR,
+        category_col="Reference Benchmark Used",
+        uses_col="Property Use",
+    )
+    copy_vo_cibse_link_from_excel_to_text_files(
+        drem.filepaths.ROUGHWORK_DIR / "vo-rows-not-caught-by-cibse.xlsx",
+        drem.filepaths.LINKS_DIR,
+        category_col="CATEGORY",
+        uses_col="Uses",
+    )

--- a/tests/unit/utilities/test_link_vo_to_cibse.py
+++ b/tests/unit/utilities/test_link_vo_to_cibse.py
@@ -1,21 +1,23 @@
 from os import listdir
 from pathlib import Path
+from typing import List
 
+import numpy as np
 import pandas as pd
 import pytest
 
-from drem.utilities.link_vo_to_cibse import copy_vo_cibse_link_from_excel_to_yamls
+from drem.utilities.link_vo_to_cibse import copy_vo_cibse_link_from_excel_to_text_files
 
 
 @pytest.fixture
-def path_to_vo_cibse_link(tmp_path: Path) -> Path:
-    """Create dummy data of vo to cibse link.
+def vo_cibse_link_excel(tmp_path: Path) -> Path:
+    """Create dummy data of vo - cibse link.
 
     Args:
         tmp_path (Path): A Pytest plugin to create a temporary path
 
     Returns:
-        Path: Path to dummy data file location
+        Path: Path to dummy excel file location
     """
     vo_cibse_link: pd.DataFrame = pd.DataFrame(
         {
@@ -23,31 +25,95 @@ def path_to_vo_cibse_link(tmp_path: Path) -> Path:
                 "KIOSK CLOTHES SHOP",
                 "COFFEE SHOP STORE",
                 "MISCELLANEOUS SURGERY",
+                np.nan,
             ],
             "CATEGORY": [
                 "General Retail (TM:46)",
                 "Retail: Small Food Shop",
                 "Clinic: Health center/Clinic/Surgery (TM46)",
+                "Clinic: Health center/Clinic/Surgery (TM46)",
             ],
         },
     )
 
-    path_to_vo_cibse_link: Path = tmp_path / "link-vo-to-cibse.xlsx"
+    vo_cibse_link_excel: Path = tmp_path / "link-vo-to-cibse.xlsx"
 
-    vo_cibse_link.to_excel(path_to_vo_cibse_link, engine="openpyxl")
+    vo_cibse_link.to_excel(vo_cibse_link_excel, engine="openpyxl")
 
-    return path_to_vo_cibse_link
+    return vo_cibse_link_excel
 
 
-def test_copy_vo_cibse_link_from_excel_to_yamls(
-    path_to_vo_cibse_link: Path, tmp_path: Path,
-) -> None:
-    """Copy VO-to-CIBSE links to a yaml named after each category containing uses.
+@pytest.fixture
+def vo_cibse_link_excel_new(tmp_path: Path) -> Path:
+    """Create new dummy data of vo - cibse link.
 
     Args:
-        path_to_vo_cibse_link (Path): Path to vo-cibse-link dummy data
         tmp_path (Path): A Pytest plugin to create a temporary path
-    """
-    copy_vo_cibse_link_from_excel_to_yamls(path_to_vo_cibse_link, tmp_path)
 
-    assert "General Retail (TM:46).yaml" in listdir(tmp_path)
+    Returns:
+        Path: Path to dummy excel file location
+    """
+    vo_cibse_link_new: pd.DataFrame = pd.DataFrame(
+        {"Uses": ["COFFEE SHOP"], "CATEGORY": ["Retail: Small Food Shop"]},
+    )
+
+    vo_cibse_link_excel_new: Path = tmp_path / "link-vo-to-cibse-new.xlsx"
+
+    vo_cibse_link_new.to_excel(vo_cibse_link_excel_new, engine="openpyxl")
+
+    return vo_cibse_link_excel_new
+
+
+@pytest.fixture
+def dir_with_text_files(vo_cibse_link_excel: Path, tmp_path: Path) -> Path:
+    """Path to directory containing vo-cibse link yamls.
+
+    Args:
+        vo_cibse_link_excel (Path): Path to dummy vo-cibse link excel data
+        tmp_path (Path): A Pytest plugin to create a temporary path
+
+    Returns:
+        Path: Path to directory containing dummy text files
+    """
+    copy_vo_cibse_link_from_excel_to_text_files(
+        vo_cibse_link_excel, tmp_path, category_col="CATEGORY", uses_col="Uses",
+    )
+
+    return tmp_path
+
+
+def test_copy_vo_cibse_link_from_excel_to_text_files(dir_with_text_files: Path) -> None:
+    """Copy VO-to-CIBSE links from excel to new text file.
+
+    Where each file is named after a category and contains corresponding uses.
+
+    Args:
+        dir_with_text_files (Path): Path to directory containing dummy text files
+    """
+    assert "General Retail (TM:46).txt" in listdir(dir_with_text_files)
+
+
+def test_copy_vo_cibse_link_from_excel_to_text_files_appends(
+    vo_cibse_link_excel_new: Path, dir_with_text_files: Path,
+) -> None:
+    """Append VO-to-CIBSE links from Excel to existing text file.
+
+    Where each file is named after a category and contains corresponding uses.
+
+    Args:
+        vo_cibse_link_excel_new (Path): Path to new vo-cibse-link dummy data
+        dir_with_text_files (Path): A Pytest plugin to create a temporary path
+    """
+    retail_text_file: Path = dir_with_text_files / "Retail: Small Food Shop.txt"
+
+    copy_vo_cibse_link_from_excel_to_text_files(
+        vo_cibse_link_excel_new,
+        dir_with_text_files,
+        category_col="CATEGORY",
+        uses_col="Uses",
+    )
+
+    with open(retail_text_file, "r") as text_file:
+        retail_values: List[str] = [item.strip() for item in text_file.readlines()]
+
+    assert set(retail_values) == {"COFFEE SHOP STORE", "COFFEE SHOP"}


### PR DESCRIPTION
Needed to append vo-cibse links from two different excels to
the same yaml files; it's more straightforward to append to text
files as yaml functionality is not required when every text file
just contains a list of strings - not complex