### PR TITLE
Add Dockerfile to automate drem dev env

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.134.1/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "..\\Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": null
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"mhutchie.git-graph",
+		"eamodio.gitlens"
+	]
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# Install & build Poetry
+# Source: https://github.com/airdock-io/docker-python-poetry
+FROM python:3.8-slim AS build-poetry
+
+ENV HOME=/usr/local/lib
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y curl \
+    && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH=$HOME/.poetry/bin:$PATH
+
+# Install & build zsh dev environment
+# Source: https://gist.github.com/MichalZalecki/4a87880bbe7a3a5428b5aebebaa5cd97
+FROM python:3.8-slim AS build-dev-env
+
+ENV HOME=/usr/local/lib
+
+COPY --from=build-poetry /usr/local/lib/.poetry /usr/local/lib/.poetry
+
+ENV PATH=$HOME/.poetry/bin:$PATH
+
+RUN apt-get update \
+    && apt-get install -y \
+    sudo \
+    curl \
+    wget \
+    git-core \
+    vim \
+    zsh \
+    fonts-powerline \
+    gcc
+
+RUN wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true \
+    && git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
+
+RUN git clone https://github.com/codema-dev/codema-dev-dotfiles $HOME/codema-dev-dotfiles/ \
+    && cp -r $HOME/codema-dev-dotfiles/. $HOME \
+    && rm -fr $HOME/codema-dev-dotfiles
+
+RUN chsh -s $(which zsh)


### PR DESCRIPTION
To opening of VSCode in a customised Docker container
with following installed:
- poetry
- zsh: oh-my-zsh, powerlevel10k
- codema-dev-dotfiles with custom aliases for zsh

Enables standardisation of the Codema-dev development
environment for the `drem` project