### PR TITLE
Remove Run CI on Push to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,6 @@
 name: build
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Runs on pull_request AND on push to master.  All merging changes must go through a Pull Request and Push so runs twice unnecessarily...