### PR TITLE
BUG: Remove none string from VO Address not caught

### DIFF
--- a/src/drem/transform/vo.py
+++ b/src/drem/transform/vo.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from re import IGNORECASE
 
 import geopandas as gpd
 import numpy as np
@@ -18,7 +19,7 @@ def _merge_address_columns_into_one(df: pd.DataFrame, on: str) -> pd.DataFrame:
 def _remove_null_address_strings(df: pd.DataFrame, on: str) -> pd.DataFrame:
 
     df[on] = (
-        df[on].astype(str).str.replace("None", "").str.replace("nan", "").str.strip()
+        df[on].astype(str).str.replace("none|nan", "", flags=IGNORECASE).str.strip()
     )
 
     return df

--- a/tests/unit/transform/test_vo.py
+++ b/tests/unit/transform/test_vo.py
@@ -47,11 +47,18 @@ def test_remove_null_address_strings() -> None:
             "Address": [
                 "7 Rowanbyrne Blackrock nan nan",
                 "7 Rowanbyrne Blackrock None None",
+                "7 Rowanbyrne Blackrock none none",
             ],
         },
     )
     expected_output = pd.DataFrame(
-        {"Address": ["7 Rowanbyrne Blackrock", "7 Rowanbyrne Blackrock"]},
+        {
+            "Address": [
+                "7 Rowanbyrne Blackrock",
+                "7 Rowanbyrne Blackrock",
+                "7 Rowanbyrne Blackrock",
+            ],
+        },
     )
 
     output: pd.DataFrame = _remove_null_address_strings(addresses, "Address")


### PR DESCRIPTION
Now 'none' string is removed in VO Addresses in `transform_vo`