### PR TITLE
Fill empty VO Address strings so parseable

### DIFF
--- a/src/drem/transform/vo.py
+++ b/src/drem/transform/vo.py
@@ -25,6 +25,15 @@ def _remove_null_address_strings(df: pd.DataFrame, on: str) -> pd.DataFrame:
     return df
 
 
+def _replace_string_in_column(
+    df: pd.DataFrame, on: str, to_replace: str, replace_with: str,
+) -> pd.DataFrame:
+
+    df[on] = df[on].astype(str).str.replace(to_replace, replace_with)
+
+    return df
+
+
 def _remove_symbols_from_column_strings(df: pd.DataFrame, column: str) -> pd.DataFrame:
 
     df[column] = df[column].astype(str).str.replace(r"[-,]", "").str.strip()
@@ -129,6 +138,9 @@ def transform_vo(
         .rename(columns=str.strip)
         .pipe(_merge_address_columns_into_one, on="Address")
         .pipe(_remove_null_address_strings, on="Address")
+        .pipe(
+            _replace_string_in_column, on="Address", to_replace="", replace_with="None",
+        )
         .pipe(_extract_use_from_vo_uses_column)
         .pipe(_merge_benchmarks_into_vo, benchmarks)
         .pipe(_save_unmatched_vo_uses_to_text_file, unmatched_txtfile)

--- a/tests/unit/transform/test_vo.py
+++ b/tests/unit/transform/test_vo.py
@@ -15,6 +15,7 @@ from drem.transform.vo import _extract_use_from_vo_uses_column
 from drem.transform.vo import _merge_address_columns_into_one
 from drem.transform.vo import _merge_benchmarks_into_vo
 from drem.transform.vo import _remove_null_address_strings
+from drem.transform.vo import _replace_string_in_column
 from drem.transform.vo import _save_unmatched_vo_uses_to_text_file
 
 
@@ -62,6 +63,18 @@ def test_remove_null_address_strings() -> None:
     )
 
     output: pd.DataFrame = _remove_null_address_strings(addresses, "Address")
+
+    assert_frame_equal(output, expected_output)
+
+
+def test_replace_string_in_column() -> None:
+    """Replace string in column with new string."""
+    addresses = pd.DataFrame({"Address": [""]})
+    expected_output = pd.DataFrame({"Address": ["None"]})
+
+    output: pd.DataFrame = _replace_string_in_column(
+        addresses, on="Address", to_replace="", replace_with="None",
+    )
 
     assert_frame_equal(output, expected_output)
 


### PR DESCRIPTION
`Pypostal` function `expand_address` fails on empty string
or "" so must fill 'em with "None"