### PR TITLE
Save VO to file at end of commercial ETL

### DIFF
--- a/src/drem/etl/commercial.py
+++ b/src/drem/etl/commercial.py
@@ -13,6 +13,7 @@ warnings.filterwarnings("ignore", message=".*initial implementation of Parquet.*
 read_parquet_to_dataframe = drem.ReadParquetToDataFrame(
     name="Read Parquet file to DataFrame",
 )
+load_to_parquet = drem.LoadToParquet(name="Load Data to Parquet file")
 
 
 with Flow("Extract, Transform & Load DREM Data") as flow:
@@ -22,6 +23,7 @@ with Flow("Extract, Transform & Load DREM Data") as flow:
     external_dir = data_dir / "external"
     benchmarks_dir = data_dir / "commercial_building_benchmarks"
     raw_dir = data_dir / "raw"
+    processed_dir = data_dir / "processed"
 
     vo_raw = read_parquet_to_dataframe(filepath=external_dir / "vo_dublin.parquet")
 
@@ -29,3 +31,5 @@ with Flow("Extract, Transform & Load DREM Data") as flow:
         benchmarks_dir, benchmarks_dir / "benchmark_energy_demands.csv",
     )
     vo_clean = drem.transform_vo(vo_raw, benchmarks, benchmarks_dir / "Unmatched.txt")
+
+    load_to_parquet(vo_clean, processed_dir / "vo_dublin.parquet")

--- a/tests/functional/test_etl_commercial.py
+++ b/tests/functional/test_etl_commercial.py
@@ -13,6 +13,10 @@ from drem.etl import commercial
 from drem.filepaths import FTEST_DATA
 
 
+def mock_task_run(*args, **kwargs) -> None:
+    return None
+
+
 @pytest.fixture
 def etl_flow_state() -> State:
     """Run etl flow with dummy test data.
@@ -20,6 +24,8 @@ def etl_flow_state() -> State:
     Returns:
         [State]: A Prefect State object containing flow run information
     """
+    # Mock out task load as CI doesn't need flow outputs on-disk
+    monkeypatch.setattr(commercial.drem.LoadToParquet, "run", mock_task_run)
     with raise_on_exception():
         state: State = commercial.flow.run(data_dir=FTEST_DATA)
 


### PR DESCRIPTION
So can read `vo_dublin.parquet` in transform `m_and_r` script...