### PR TITLE
Refactor transform sa stats into flow

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -90,6 +90,10 @@ ignore =
     RST201
     # -> Fails when include an example in docstring ...
 
+    # Found too many arguments
+    # -> some functions exceed this ...
+    WPS211
+
 import-order-style=google
 
 [darglint]

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,9 @@ ignore =
     # -> some functions exceed this ...
     WPS211
 
+    #  '.pivot_table' is preferred to '.pivot' or '.unstack'; provides same functionality
+    PD010
+
 import-order-style=google
 
 [darglint]

--- a/src/drem/__init__.py
+++ b/src/drem/__init__.py
@@ -11,5 +11,4 @@ from drem.transform.benchmarks import transform_benchmarks
 from drem.transform.ber import transform_ber
 from drem.transform.dublin_postcodes import transform_dublin_postcodes
 from drem.transform.sa_geometries import transform_sa_geometries
-from drem.transform.sa_statistics import transform_sa_statistics
 from drem.transform.vo import transform_vo

--- a/src/drem/etl/residential.py
+++ b/src/drem/etl/residential.py
@@ -10,18 +10,23 @@ import drem
 
 from drem.estimate.sa_demand import EstimateSmallAreaDemand
 from drem.filepaths import DATA_DIR
+from drem.transform.sa_statistics import TransformSaStatistics
 
 
 warnings.filterwarnings("ignore", message=".*initial implementation of Parquet.*")
 
 # Enable checkpointing for pipeline-persisted results
 prefect.config.flows.checkpointing = True
+
 email_address = PrefectSecret("email_address")
 
 read_parquet_to_dataframe = drem.ReadParquetToDataFrame(
     name="Read Parquet file to DataFrame",
 )
+
 estimate_sa_demand = EstimateSmallAreaDemand()
+transform_sa_statistics = TransformSaStatistics()
+
 load_to_parquet = drem.LoadToParquet(name="Load Data to Parquet file")
 
 
@@ -41,11 +46,11 @@ with Flow("Extract, Transform & Load DREM Data") as flow:
     sa_geometries_clean = drem.transform_sa_geometries(sa_geometries_raw)
     dublin_postcodes_clean = drem.transform_dublin_postcodes(dublin_postcodes_raw)
     ber_clean = drem.transform_ber(ber_raw)
-    sa_statistics_clean = drem.transform_sa_statistics(
-        sa_statistics_raw,
-        sa_statistics_glossary,
-        sa_geometries_clean,
-        dublin_postcodes_clean,
+    sa_statistics_clean = transform_sa_statistics(
+        raw_sa_statistics=sa_statistics_raw,
+        raw_sa_glossary=sa_statistics_glossary,
+        dublin_postcodes=dublin_postcodes_clean,
+        dublin_sa_geometries=sa_geometries_clean,
     )
 
     sa_demand = estimate_sa_demand(sa_statistics_clean, ber_clean, sa_geometries_clean)

--- a/src/drem/transform/sa_statistics.py
+++ b/src/drem/transform/sa_statistics.py
@@ -96,6 +96,15 @@ def _replace_substring_in_column(
     return df
 
 
+def _strip_column(
+    df: pd.DataFrame, target: str, result: str, **kwargs: Any,
+) -> pd.DataFrame:
+
+    df[result] = df[target].str.strip(**kwargs)
+
+    return df
+
+
 def _clean_year_built_columns(df: pd.DataFrame) -> pd.DataFrame:
 
     return (

--- a/src/drem/transform/sa_statistics.py
+++ b/src/drem/transform/sa_statistics.py
@@ -25,12 +25,15 @@ def _extract_rows_from_glossary(
     return glossary.iloc[start_row:end_row].reset_index(drop=True)
 
 
-@require(lambda columns: len(columns) == 2)
 def _convert_columns_to_dict(
-    extracted_table: pd.DataFrame, columns: str,
+    extracted_table: pd.DataFrame, column_name_index: str, column_name_values: str,
 ) -> Dict[str, str]:
 
-    return extracted_table[columns].set_index(columns[0]).to_dict()[columns[1]]
+    return (
+        extracted_table[[column_name_index, column_name_values]]
+        .set_index(column_name_index)
+        .to_dict()[column_name_values]
+    )
 
 
 def _extract_column_names_via_glossary(

--- a/src/drem/transform/sa_statistics.py
+++ b/src/drem/transform/sa_statistics.py
@@ -72,6 +72,21 @@ def _melt_columns(df: pd.DataFrame, id_vars: List[str], **kwargs: Any) -> pd.Dat
     return df.melt(id_vars=id_vars, **kwargs)
 
 
+def _split_column_in_two_on_substring(
+    df: pd.DataFrame,
+    target: str,
+    pat: str,
+    left_column_name: str,
+    right_column_name: str,
+) -> pd.DataFrame:
+
+    df[[left_column_name, right_column_name]] = df[target].str.split(
+        pat=pat, expand=True,
+    )
+
+    return df
+
+
 def _clean_year_built_columns(df: pd.DataFrame) -> pd.DataFrame:
 
     return (

--- a/src/drem/transform/sa_statistics.py
+++ b/src/drem/transform/sa_statistics.py
@@ -87,6 +87,15 @@ def _split_column_in_two_on_substring(
     return df
 
 
+def _replace_substring_in_column(
+    df: pd.DataFrame, target: str, result: str, pat: str, repl: str, **kwargs: Any,
+) -> pd.DataFrame:
+
+    df[result] = df[target].str.replace(pat=pat, repl=repl, **kwargs)
+
+    return df
+
+
 def _clean_year_built_columns(df: pd.DataFrame) -> pd.DataFrame:
 
     return (

--- a/tests/functional/transform/test_sa_statistics.py
+++ b/tests/functional/transform/test_sa_statistics.py
@@ -1,0 +1,123 @@
+from io import StringIO
+
+import pandas as pd
+import pytest
+
+from pandas.testing import assert_frame_equal
+from prefect.engine.state import State
+from prefect.utilities.debug import raise_on_exception
+
+from drem.transform.sa_statistics import TransformSaStatistics
+from drem.transform.sa_statistics import clean_year_built
+from drem.transform.sa_statistics import flow
+
+
+transform_sa_statistics = TransformSaStatistics()
+
+
+@pytest.fixture
+def raw_sa_glossary() -> pd.DataFrame:
+    """Create Raw Small Area Statistics Glossary.
+
+    Returns:
+        pd.DataFrame: Raw glossary table
+    """
+    return pd.DataFrame(
+        {
+            "Tables Within Themes": [
+                "Table 1",
+                "Private households by type of accommodation ",
+                "Table 2",
+                "Permanent private households by year built ",
+                "Table 5",
+                "Permanent private households by central heating ",
+            ],
+            "Column Names": [
+                "T6_1_HB_H",
+                "T6_1_FA_H",
+                "T6_2_PRE19H",
+                "T6_2_19_45H",
+                "T6_5_NCH",
+                "T6_5_OCH",
+            ],
+            "Description of Field": [
+                "House/Bungalow (No. of households)",
+                "Flat/Apartment (No. of persons)",
+                "Pre 1919 (No. of households)",
+                "1919 - 1945 (No. of persons)",
+                "No central heating",
+                "Oil",
+            ],
+        },
+    )
+
+
+@pytest.fixture
+def raw_sa_statistics() -> pd.DataFrame:
+    """Create Raw Small Area Statistics.
+
+    Returns:
+        pd.DataFrame: Raw Statistics
+    """
+    return pd.DataFrame(
+        {
+            "GEOGID": ["SA2017_017001001"],
+            "T6_1_HB_H": [2],
+            "T6_1_FA_H": [3],
+            "T6_2_PRE19H": [10],
+            "T6_2_19_45H": [20],
+            "T6_5_NCH": [7],
+            "T6_5_OCH": 12,
+        },
+    )
+
+
+@pytest.fixture
+def flow_state(
+    raw_sa_glossary: pd.DataFrame, raw_sa_statistics: pd.DataFrame,
+) -> State:
+    """Run etl flow with dummy test data.
+
+    Args:
+        raw_sa_glossary (pd.DataFrame): Raw glossary table
+        raw_sa_statistics (pd.DataFrame): Raw Ireland Small Area Statistics
+
+    Returns:
+        State: A Prefect State object containing flow run information
+
+    """
+    with raise_on_exception():
+        state = flow.run(
+            dict(raw_sa_glossary=raw_sa_glossary, raw_sa_stats=raw_sa_statistics),
+        )
+
+    return state
+
+
+def test_no_transform_sa_stats_tasks_fail(flow_state: State) -> None:
+    """No etl tasks fail.
+
+    Args:
+        flow_state (State): A Prefect State object containing flow run information
+    """
+    assert flow_state.is_successful()
+
+
+def test_transform_year_built_matches_expected(flow_state: State) -> None:
+    """Transform year built data matches expected.
+
+    Args:
+        flow_state (State): A Prefect State object containing flow run information
+    """
+    expected_output = pd.read_csv(
+        StringIO(
+            """small_area, period_built, households, persons
+            017001001, Pre 1919, 0.0, NaN
+            017001001, 1919 - 1945, NaN, 20.0
+            """,
+        ),
+    )
+
+    output = flow_state.result[clean_year_built].result
+
+    assert assert_frame_equal(output, expected_output)

--- a/tests/functional/transform/test_sa_statistics.py
+++ b/tests/functional/transform/test_sa_statistics.py
@@ -110,8 +110,8 @@ def flow_state(
     """Run etl flow with dummy test data.
 
     Args:
-        raw_sa_glossary (pd.DataFrame): Raw glossary table
         raw_sa_statistics (pd.DataFrame): Raw Ireland Small Area Statistics
+        raw_sa_glossary (pd.DataFrame): Raw glossary table
         dublin_postcodes (gpd.GeoDataFrame): Dublin Postcodes
         dublin_sa_geometries (gpd.GeoDataFrame): Dublin Small Area Geometries
 
@@ -121,8 +121,8 @@ def flow_state(
     with raise_on_exception():
         state = flow.run(
             dict(
-                raw_sa_glossary=raw_sa_glossary,
                 raw_sa_stats=raw_sa_statistics,
+                raw_sa_glossary=raw_sa_glossary,
                 dublin_pcodes=dublin_postcodes,
                 dublin_sa_geom=dublin_sa_geometries,
             ),

--- a/tests/unit/transform/test_sa_statistics.py
+++ b/tests/unit/transform/test_sa_statistics.py
@@ -20,7 +20,7 @@ from drem.transform.sa_statistics import _extract_dublin_small_areas
 from drem.transform.sa_statistics import _extract_rows_from_glossary
 from drem.transform.sa_statistics import _link_dublin_small_areas_to_geometries
 from drem.transform.sa_statistics import _link_small_areas_to_postcodes
-from drem.transform.sa_statistics import _melt_year_built_columns
+from drem.transform.sa_statistics import _melt_columns
 from drem.transform.sa_statistics import _rename_columns_via_glossary
 
 
@@ -220,17 +220,38 @@ def test_rename_columns_via_glossary(year_built_glossary: Dict[str, str]) -> Non
     assert_frame_equal(output, expected_output)
 
 
-def test_melt_year_built_columns(ref: ReferenceTest) -> None:
-    """Melted columns match (tdda generated) reference file.
+def test_melt_columns() -> None:
+    """Melt selected columns to rows."""
+    before_melt = pd.DataFrame(
+        {
+            "GEOGID": ["SA2017_017001001"],
+            "Pre 1919 (No. of households)": [10],
+            "1919 - 1945 (No. of households)": [20],
+            "Pre 1919 (No. of persons)": [25],
+            "1919 - 1945 (No. of persons)": [40],
+        },
+    )
+    expected_output = pd.DataFrame(
+        {
+            "GEOGID": [
+                "SA2017_017001001",
+                "SA2017_017001001",
+                "SA2017_017001001",
+                "SA2017_017001001",
+            ],
+            "variable": [
+                "Pre 1919 (No. of households)",
+                "1919 - 1945 (No. of households)",
+                "Pre 1919 (No. of persons)",
+                "1919 - 1945 (No. of persons)",
+            ],
+            "value": [10, 20, 25, 40],
+        },
+    )
 
-    Args:
-        ref (ReferenceTest): a tdda plugin used to verify a DataFrame against a file.
-    """
-    statistics = pd.read_csv(EXTRACT_EOUT)
+    output = _melt_columns(before_melt, id_vars="GEOGID")
 
-    output = _melt_year_built_columns(statistics)
-
-    ref.assertDataFrameCorrect(output, MELT_EOUT)
+    assert_frame_equal(output, expected_output)
 
 
 def test_clean_year_built_columns(ref: ReferenceTest) -> None:

--- a/tests/unit/transform/test_sa_statistics.py
+++ b/tests/unit/transform/test_sa_statistics.py
@@ -24,6 +24,7 @@ from drem.transform.sa_statistics import _melt_columns
 from drem.transform.sa_statistics import _rename_columns_via_glossary
 from drem.transform.sa_statistics import _replace_substring_in_column
 from drem.transform.sa_statistics import _split_column_in_two_on_substring
+from drem.transform.sa_statistics import _strip_column
 
 
 STATS_IN: Path = UTEST_DATA_TRANSFORM / "sa_statistics_raw.csv"
@@ -288,6 +289,18 @@ def test_replace_substring_in_column() -> None:
         pat=r"(No. of )|(\))",
         repl="",
     )
+
+    assert_frame_equal(output, expected_output)
+
+
+def test_strip_column() -> None:
+    """Strip column strings of whitespace."""
+    before_strip = pd.DataFrame({"dirty_column": ["Pre 1919 "]})
+    expected_output = pd.DataFrame(
+        {"dirty_column": ["Pre 1919 "], "clean_column": ["Pre 1919"]},
+    )
+
+    output = _strip_column(before_strip, target="dirty_column", result="clean_column")
 
     assert_frame_equal(output, expected_output)
 

--- a/tests/unit/transform/test_sa_statistics.py
+++ b/tests/unit/transform/test_sa_statistics.py
@@ -22,6 +22,7 @@ from drem.transform.sa_statistics import _link_dublin_small_areas_to_geometries
 from drem.transform.sa_statistics import _link_small_areas_to_postcodes
 from drem.transform.sa_statistics import _melt_columns
 from drem.transform.sa_statistics import _rename_columns_via_glossary
+from drem.transform.sa_statistics import _split_column_in_two_on_substring
 
 
 STATS_IN: Path = UTEST_DATA_TRANSFORM / "sa_statistics_raw.csv"
@@ -250,6 +251,66 @@ def test_melt_columns() -> None:
     )
 
     output = _melt_columns(before_melt, id_vars="GEOGID")
+
+    assert_frame_equal(output, expected_output)
+
+
+def test_split_column_in_two_on_substring() -> None:
+    """Split column in two on substring."""
+    before_split = pd.DataFrame(
+        {
+            "GEOGID": [
+                "SA2017_017001001",
+                "SA2017_017001001",
+                "SA2017_017001001",
+                "SA2017_017001001",
+            ],
+            "variable": [
+                "Pre 1919 (No. of households)",
+                "1919 - 1945 (No. of households)",
+                "Pre 1919 (No. of persons)",
+                "1919 - 1945 (No. of persons)",
+            ],
+            "value": [10, 20, 25, 40],
+        },
+    )
+    expected_output = pd.DataFrame(
+        {
+            "GEOGID": [
+                "SA2017_017001001",
+                "SA2017_017001001",
+                "SA2017_017001001",
+                "SA2017_017001001",
+            ],
+            "variable": [
+                "Pre 1919 (No. of households)",
+                "1919 - 1945 (No. of households)",
+                "Pre 1919 (No. of persons)",
+                "1919 - 1945 (No. of persons)",
+            ],
+            "value": [10, 20, 25, 40],
+            "raw_year_built": [
+                "Pre 1919 ",
+                "1919 - 1945 ",
+                "Pre 1919 ",
+                "1919 - 1945 ",
+            ],
+            "raw_households_and_persons": [
+                "No. of households)",
+                "No. of households)",
+                "No. of persons)",
+                "No. of persons)",
+            ],
+        },
+    )
+
+    output = _split_column_in_two_on_substring(
+        before_split,
+        target="variable",
+        pat=r"(",
+        left_column_name="raw_year_built",
+        right_column_name="raw_households_and_persons",
+    )
 
     assert_frame_equal(output, expected_output)
 

--- a/tests/unit/transform/test_sa_statistics.py
+++ b/tests/unit/transform/test_sa_statistics.py
@@ -22,6 +22,7 @@ from drem.transform.sa_statistics import _link_dublin_small_areas_to_geometries
 from drem.transform.sa_statistics import _link_small_areas_to_postcodes
 from drem.transform.sa_statistics import _melt_columns
 from drem.transform.sa_statistics import _rename_columns_via_glossary
+from drem.transform.sa_statistics import _replace_substring_in_column
 from drem.transform.sa_statistics import _split_column_in_two_on_substring
 
 
@@ -227,26 +228,14 @@ def test_melt_columns() -> None:
         {
             "GEOGID": ["SA2017_017001001"],
             "Pre 1919 (No. of households)": [10],
-            "1919 - 1945 (No. of households)": [20],
             "Pre 1919 (No. of persons)": [25],
-            "1919 - 1945 (No. of persons)": [40],
         },
     )
     expected_output = pd.DataFrame(
         {
-            "GEOGID": [
-                "SA2017_017001001",
-                "SA2017_017001001",
-                "SA2017_017001001",
-                "SA2017_017001001",
-            ],
-            "variable": [
-                "Pre 1919 (No. of households)",
-                "1919 - 1945 (No. of households)",
-                "Pre 1919 (No. of persons)",
-                "1919 - 1945 (No. of persons)",
-            ],
-            "value": [10, 20, 25, 40],
+            "GEOGID": ["SA2017_017001001", "SA2017_017001001"],
+            "variable": ["Pre 1919 (No. of households)", "Pre 1919 (No. of persons)"],
+            "value": [10, 25],
         },
     )
 
@@ -259,48 +248,18 @@ def test_split_column_in_two_on_substring() -> None:
     """Split column in two on substring."""
     before_split = pd.DataFrame(
         {
-            "GEOGID": [
-                "SA2017_017001001",
-                "SA2017_017001001",
-                "SA2017_017001001",
-                "SA2017_017001001",
-            ],
-            "variable": [
-                "Pre 1919 (No. of households)",
-                "1919 - 1945 (No. of households)",
-                "Pre 1919 (No. of persons)",
-                "1919 - 1945 (No. of persons)",
-            ],
-            "value": [10, 20, 25, 40],
+            "GEOGID": ["SA2017_017001001"],
+            "variable": ["Pre 1919 (No. of households)"],
+            "value": [10],
         },
     )
     expected_output = pd.DataFrame(
         {
-            "GEOGID": [
-                "SA2017_017001001",
-                "SA2017_017001001",
-                "SA2017_017001001",
-                "SA2017_017001001",
-            ],
-            "variable": [
-                "Pre 1919 (No. of households)",
-                "1919 - 1945 (No. of households)",
-                "Pre 1919 (No. of persons)",
-                "1919 - 1945 (No. of persons)",
-            ],
-            "value": [10, 20, 25, 40],
-            "raw_year_built": [
-                "Pre 1919 ",
-                "1919 - 1945 ",
-                "Pre 1919 ",
-                "1919 - 1945 ",
-            ],
-            "raw_households_and_persons": [
-                "No. of households)",
-                "No. of households)",
-                "No. of persons)",
-                "No. of persons)",
-            ],
+            "GEOGID": ["SA2017_017001001"],
+            "variable": ["Pre 1919 (No. of households)"],
+            "value": [10],
+            "raw_year_built": ["Pre 1919 "],
+            "raw_households_and_persons": ["No. of households)"],
         },
     )
 
@@ -310,6 +269,24 @@ def test_split_column_in_two_on_substring() -> None:
         pat=r"(",
         left_column_name="raw_year_built",
         right_column_name="raw_households_and_persons",
+    )
+
+    assert_frame_equal(output, expected_output)
+
+
+def test_replace_substring_in_column() -> None:
+    """Replace substring in column."""
+    before_removal = pd.DataFrame({"dirty_column": ["No. of households)"]})
+    expected_output = pd.DataFrame(
+        {"dirty_column": ["No. of households)"], "clean_column": ["households"]},
+    )
+
+    output = _replace_substring_in_column(
+        before_removal,
+        target="dirty_column",
+        result="clean_column",
+        pat=r"(No. of )|(\))",
+        repl="",
     )
 
     assert_frame_equal(output, expected_output)

--- a/tests/unit/transform/test_sa_statistics.py
+++ b/tests/unit/transform/test_sa_statistics.py
@@ -164,21 +164,12 @@ def test_convert_columns_to_dict_as_expected(
     expected_output = year_built_glossary
 
     output = _convert_columns_to_dict(
-        raw_year_built_glossary, columns=["Column Names", "Description of Field"],
+        raw_year_built_glossary,
+        column_name_index="Column Names",
+        column_name_values="Description of Field",
     )
 
     assert output == expected_output
-
-
-def test_convert_columns_to_dict_raises_error_with_invalid_arg() -> None:
-    """Convert columns fails if > 2 columns passed."""
-    input_table = pd.DataFrame(
-        {"Column1": [0, 1, 2], "Column2": [0, 1, 2], "Column3": [0, 1, 2]},
-    )
-    with pytest.raises(ViolationError):
-        _convert_columns_to_dict(
-            input_table, columns=["Column1", "Column2", "Column3"],
-        )
 
 
 def test_extract_year_built_column_names_via_glossary(


### PR DESCRIPTION
Refactored cleaning functions into modular prefect tasks that can be used like lego blocks to extract any small area statistics table from the raw data source, clean & link to geometries.  

Previous implementation was not adaptable to other statistics tables.   Next step is redoing above process for dwelling type and boiler type; instead of outputting sa_stats as a GeoDataFrame instead output a Dict of Small Area Statistics.

Also added a Functional test to check transform flow outputs expected data for dummy inputs...