### PR TITLE
Refactor all transform tasks to save to file

### DIFF
--- a/src/drem/transform/ber.py
+++ b/src/drem/transform/ber.py
@@ -86,21 +86,18 @@ class TransformBER(Task, VisualizeMixin):
         self.flow = flow
         super().__init__(**kwargs)
 
-    def run(self, dirpath: Path, filename: str) -> pd.DataFrame:
+    def run(self, input_filepath: Path, output_filepath: Path) -> None:
         """Run flow.
 
         Args:
-            dirpath (Path): Directory where data is stored
-            filename (str): Name of data
-
-        Returns:
-            pd.DataFrame: Clean BER Data
+            input_filepath (Path): Path to input data
+            output_filepath (Path): Path to output data
         """
-        ber_filepath = dirpath / f"{filename}.parquet"
         with raise_on_exception():
-            state = self.flow.run(parameters=dict(ber_fpath=ber_filepath))
+            state = self.flow.run(parameters=dict(ber_fpath=input_filepath))
 
-        return state.result[bin_year_built_into_census_categories].result
+        result = state.result[bin_year_built_into_census_categories].result
+        result.to_parquet(output_filepath)
 
 
 transform_ber = TransformBER()

--- a/src/drem/transform/dublin_postcodes.py
+++ b/src/drem/transform/dublin_postcodes.py
@@ -3,8 +3,6 @@ import re
 from pathlib import Path
 from typing import Any
 
-import geopandas as gpd
-
 from prefect import Flow
 from prefect import Parameter
 from prefect import Task
@@ -59,20 +57,16 @@ class TransformDublinPostcodes(Task, VisualizeMixin):
         self.flow = flow
         super().__init__(**kwargs)
 
-    def run(self, dirpath: Path, filename: str) -> gpd.GeoDataFrame:
+    def run(self, input_filepath: Path, output_filepath: Path) -> None:
         """Run module flow.
 
         Args:
-            dirpath (Path): Directory where data is stored
-            filename (str): Name of data
-
-        Returns:
-            gpd.GeoDataFrame: Clean Dublin Postcode Geometries
+            input_filepath (Path): Path to input data
+            output_filepath (Path): Path to output data
         """
-        filepath = dirpath / f"{filename}.parquet"
-
-        state = self.flow.run(fpath=filepath)
-        return state.result[clean_postcodes].result
+        state = self.flow.run(fpath=input_filepath)
+        result = state.result[clean_postcodes].result
+        result.to_parquet(output_filepath)
 
 
 transform_dublin_postcodes = TransformDublinPostcodes()

--- a/src/drem/transform/sa_geometries.py
+++ b/src/drem/transform/sa_geometries.py
@@ -27,21 +27,19 @@ def extract_dublin_local_authorities(geometries: gpd.GeoDataFrame) -> gpd.GeoDat
 
 
 @task(name="Transform Small Area Geometries")
-def transform_sa_geometries(dirpath: Path, filename: str) -> gpd.GeoDataFrame:
+def transform_sa_geometries(input_filepath: Path, output_filepath: Path) -> None:
     """Transform Small Area geometries.
 
     Args:
-        dirpath (Path): Directory where data is stored
-        filename (str): Name of data
-
-    Returns:
-        gpd.GeoDataFrame: Clean Small Area Geometries
+        input_filepath (Path): Path to Raw Small Area Geometries Data
+        output_filepath (Path): Path to Clean Small Area Geometries Data
     """
-    filepath = dirpath / f"{filename}.parquet"
-    return (
-        gpd.read_parquet(filepath)
+    sa_geometries = (
+        gpd.read_parquet(input_filepath)
         .pipe(extract_dublin_local_authorities)
         .to_crs("epsg:4326")
         .loc[:, ["SMALL_AREA", "geometry"]]
         .rename(columns={"SMALL_AREA": "small_area"})
     )
+
+    sa_geometries.to_parquet(output_filepath)

--- a/tests/functional/etl/test_residential.py
+++ b/tests/functional/etl/test_residential.py
@@ -40,7 +40,6 @@ def etl_flow_state(monkeypatch: MonkeyPatch, tmp_path: Path) -> State:
     )
 
     # Mock out task load as CI doesn't need flow outputs on-disk
-    monkeypatch.setattr(residential.LoadToParquet, "run", mock_task_run)
     monkeypatch.setattr(
         residential.Download, "run", mock_task_run,
     )
@@ -51,9 +50,10 @@ def etl_flow_state(monkeypatch: MonkeyPatch, tmp_path: Path) -> State:
     # Copy test data to temporary directory
     external_dir = tmp_path / "external"
     copytree(FTEST_EXTERNAL_DIR, external_dir)
+    mkdir(tmp_path / "processed")
 
     with raise_on_exception():
-        state = residential.flow.run(external_dir=external_dir)
+        state = residential.flow.run(data_dir=tmp_path)
 
     return state
 


### PR DESCRIPTION
Previously the transform tasks took in DataFrames &
filepaths and so could only be run in an etl flow context.
Now each task saves its result to a file so only need to run
the etl flow once to transform all data & save to file so
can run each transform individually once these files have
been generated.  This will massively speed up playing-around
with data in ipython or notebooks as there's no need to
generate a flow each time