### PR TITLE
Replace pytest config with pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,17 @@ build-backend = "poetry.masonry.api"
 [tool.dephell.main]
 from = "pyproject.toml"
 to = "setup.py"
+
+
+[tool.pytest.ini_options]
+addopts = "--strict-markers"
+markers = [
+    "e2e: marks end-to-end tests which take longer to run as exercise multiple functions",
+]
+testpaths = ["tests"]
+filterwarnings = [
+    "error",
+    "ignore::UserWarning",
+    "ignore::FutureWarning",
+    "ignore::PendingDeprecationWarning",
+]

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,9 +1,0 @@
-[pytest]
-addopts = --strict-markers
-markers =
-    slow: marks tests as slow (deselect with '-m "not slow"')
-    e2e: marks end-to-end tests which take longer to run as exercise multiple functions
-filterwarnings =
-    ignore::UserWarning
-    ignore::FutureWarning
-    ignore::PendingDeprecationWarning


### PR DESCRIPTION
So all drem configuration is in one place - the pyproject toml
file...