### PR TITLE
Update README with latest drem setup guide

### DIFF
--- a/run-drem.ipynb
+++ b/run-drem.ipynb
@@ -11,7 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<span style=\"color:red\">__Register your email address with SEAI https://ndber.seai.ie/BERResearchTool/Register/Register.aspx__</span>"
+    "<span style=\"color:red\">__Warning!__</span>\n",
+    "\n",
+    "You must first register your email address with SEAI at https://ndber.seai.ie/BERResearchTool/Register/Register.aspx"
    ]
   },
   {


### PR DESCRIPTION
Latest setup relies on docker to create a reproducible build
of drem.  Has been simplified so should be usable without prior
Python, git or docker experience