### PR TITLE
Create task to activate breakpoint within flow

### DIFF
--- a/src/drem/utilities/breakpoint.py
+++ b/src/drem/utilities/breakpoint.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from prefect import task
+
+
+@task
+def flow_breakpoint(**kwargs: Any) -> None:
+    """Drop in a prefect.Flow to inspect local tasks.
+
+    Example:
+        ```python
+        from prefect import Flow
+        from prefect import task
+
+        @task
+        def create_data():
+            return [1,2,3]
+
+        with Flow("Example") as flow:
+            data = create_data()
+            flow_breakpoint(data=data)
+        ```
+        Can now access this object within `pdb` with kwargs["data"]   
+    """
+    breakpoint()  # noqa


### PR DESCRIPTION
Can drop-in this task to act as a prefect flow debugger and
inspect any flow object.

Example:
```python
from prefect import Flow
from prefect import task

@task
def create_data():
    return [1,2,3]

with Flow("Example") as flow:
    data = create_data()
    flow_breakpoint(data=data)
```
Can now access this object within `pdb` with `kwargs["data"]`