### PR TITLE
Set ber dtypes prior to read csv

### DIFF
--- a/src/drem/convert.py
+++ b/src/drem/convert.py
@@ -1,0 +1,45 @@
+import json
+
+from os import path
+
+import dask.dataframe as dd
+import prefect
+
+from prefect import Task
+
+
+class BerPublicSearchToDaskParquet(Task):
+    """Create prefect.Task to Convert BERPublicsearch to Dask Parquet.
+
+    Args:
+        Task (prefect.Task): see  https://docs.prefect.io/core/concepts/tasks.html
+    """
+
+    def run(
+        self, input_filepath: str, output_filepath: str, dtypes_filepath: str,
+    ) -> None:
+        """Convert csv file to parquet.
+
+        Args:
+            input_filepath (str): Path to input data
+            output_filepath (str): Path to output data
+            dtypes_filepath (str): Path to file containing dtypes
+        """
+        logger = prefect.context.get("logger")
+        if path.exists(output_filepath):
+            logger.info(f"{output_filepath} already exists")
+
+        else:
+            with open(dtypes_filepath, "r") as json_file:
+                dtypes = json.load(json_file)
+
+            csv = dd.read_csv(
+                input_filepath,
+                sep="\t",
+                encoding="latin-1",
+                error_bad_lines=False,
+                low_memory=False,
+                dtype=dtypes,
+            )
+
+            csv.to_parquet(output_filepath, schema="infer")

--- a/src/drem/filepaths.py
+++ b/src/drem/filepaths.py
@@ -14,6 +14,7 @@ EXTERNAL_DIR = DATA_DIR / "external"
 REQUESTS_DIR = DATA_DIR / "requests"
 ROUGHWORK_DIR = DATA_DIR / "roughwork"
 COMMERCIAL_BENCHMARKS_DIR = DATA_DIR / "commercial_building_benchmarks"
+DTYPES_DIR = DATA_DIR / "dtypes"
 
 FTEST_DIR = TEST_DIR / "functional" / "data"
 FTEST_EXTERNAL_DIR = TEST_DIR / "functional" / "data" / "external"

--- a/tests/functional/etl/test_residential.py
+++ b/tests/functional/etl/test_residential.py
@@ -15,6 +15,7 @@ from prefect import Task
 from prefect.engine.state import State
 from prefect.utilities.debug import raise_on_exception
 
+from drem.filepaths import DTYPES_DIR
 from drem.filepaths import FTEST_EXTERNAL_DIR
 
 
@@ -26,8 +27,9 @@ def mock_data_dir(tmp_path) -> Mock:
         tmp_path(Path): See https://docs.pytest.org/en/stable/tmpdir.html
     """
     # Copy test data to temporary directory
-    external_dir = tmp_path / "external"
-    copytree(FTEST_EXTERNAL_DIR, external_dir)
+    copytree(FTEST_EXTERNAL_DIR, tmp_path / "external")
+    copytree(DTYPES_DIR, tmp_path / "dtypes")
+    mkdir(tmp_path / "interim")
     mkdir(tmp_path / "processed")
 
     with patch(


### PR DESCRIPTION
`dask.dataframe` tends to break if dtypes are not
set prior to `read_csv` as its dtype inference fails;
previously had mitigated this by setting the dtype for
only columns that had so far failed, this PR sets dtype
for all columns... (so now won't fail when BERPublicsearch
updates)