### PR TITLE
Change read berpublicsearch encoding to unicode_escape

### DIFF
--- a/src/drem/convert.py
+++ b/src/drem/convert.py
@@ -36,7 +36,7 @@ class BerPublicSearchToDaskParquet(Task):
             csv = dd.read_csv(
                 input_filepath,
                 sep="\t",
-                encoding="latin-1",
+                encoding="unicode_escape",
                 error_bad_lines=False,
                 low_memory=False,
                 dtype=dtypes,


### PR DESCRIPTION
Previously encoding was `latin-1` which failed to decode BERPublicsearch with 

```python
Unexpected error: ParserError('Error tokenizing data. C error: EOF inside string starting at row 56223')
```