### PR TITLE
Add option to skip ci [ci skip]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,10 @@ on:
 jobs:
   build:
 
+    name: Build and test
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+
     strategy:
       matrix:
         python-version: [3.8]


### PR DESCRIPTION
If just changing the README then there's no
need to run CI as the code under testing hasn't
changed.  CI will be skipped if commit message
first line / title contains the string 'ci skip'

Found at https://github.com/marketplace/actions/skip-based-on-commit-message