### PR TITLE
Change poetry CI action to abatilo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         python-version:  ${{ matrix.python-version }}
 
     - name: Install Poetry
-      uses: dschep/install-poetry-action@v1.2
+      uses: abatilo/actions-poetry@v2.0.0
 
     - name: Cache Poetry virtualenv
       uses: actions/cache@v2


### PR DESCRIPTION
Previous action to install poetry in CI used
`dschep/install-poetry-action@v1.2` which bugged out
in #208 with::
```
Error: Unable to process command '##[add-path]/home/runner/.poetry/bin' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

abatilo action should resolve this issue